### PR TITLE
[FEATURE] Create Max Length Validator

### DIFF
--- a/src/validation/validators/builder/ValidationBuilder.spec.ts
+++ b/src/validation/validators/builder/ValidationBuilder.spec.ts
@@ -3,6 +3,7 @@ import {
   RequiredFieldValidation,
   EmailFieldValidation,
   MinLengthValidation,
+  MaxLengthValidation,
 } from '@/validation/validators';
 import { ValidationBuilder } from './ValidationBuilder';
 import faker from 'faker';
@@ -27,6 +28,13 @@ describe('ValidationBuilder', () => {
     expect(validations).toEqual([new MinLengthValidation(field, length)]);
   });
 
+  test('Should return MaxLengthValidation ', () => {
+    const field = faker.database.column();
+    const length = faker.datatype.number();
+    const validations = ValidationBuilder.field(field).max(length).build();
+    expect(validations).toEqual([new MaxLengthValidation(field, length)]);
+  });
+
   test('Should return CompareFieldsValidation ', () => {
     const field = faker.database.column();
     const fieldToCompare = faker.database.column();
@@ -41,16 +49,19 @@ describe('ValidationBuilder', () => {
   test('Should return a list of validations ', () => {
     const field = faker.database.column();
     const fieldToCompare = faker.database.column();
-    const length = faker.datatype.number();
+    const minLength = faker.datatype.number();
+    const maxLength = minLength + faker.datatype.number();
     const validations = ValidationBuilder.field(field)
       .required()
-      .min(length)
+      .min(minLength)
+      .max(maxLength)
       .sameAs(fieldToCompare)
       .email()
       .build();
     expect(validations).toEqual([
       new RequiredFieldValidation(field),
-      new MinLengthValidation(field, length),
+      new MinLengthValidation(field, minLength),
+      new MaxLengthValidation(field, maxLength),
       new CompareFieldsValidation(field, fieldToCompare),
       new EmailFieldValidation(field),
     ]);

--- a/src/validation/validators/builder/ValidationBuilder.ts
+++ b/src/validation/validators/builder/ValidationBuilder.ts
@@ -4,6 +4,7 @@ import {
   RequiredFieldValidation,
   EmailFieldValidation,
   MinLengthValidation,
+  MaxLengthValidation,
 } from '@/validation/validators';
 
 export class ValidationBuilder {
@@ -31,8 +32,15 @@ export class ValidationBuilder {
     return this;
   }
 
+  max(length: number): ValidationBuilder {
+    this.validations.push(new MaxLengthValidation(this.fieldName, length));
+    return this;
+  }
+
   sameAs(fieldToCompare: string): ValidationBuilder {
-    this.validations.push(new CompareFieldsValidation(this.fieldName, fieldToCompare));
+    this.validations.push(
+      new CompareFieldsValidation(this.fieldName, fieldToCompare)
+    );
     return this;
   }
 

--- a/src/validation/validators/index.ts
+++ b/src/validation/validators/index.ts
@@ -2,5 +2,6 @@ export * from './builder/ValidationBuilder';
 export * from './compareFields/CompareFieldsValidation';
 export * from './emailField/EmailFieldValidation';
 export * from './minLength/MinLengthValidation';
+export * from './maxLength/MaxLengthValidation';
 export * from './requiredField/RequiredFieldValidation';
 export * from './validationComposite/ValidationComposite';

--- a/src/validation/validators/maxLength/MaxLengthValidation.spec.ts
+++ b/src/validation/validators/maxLength/MaxLengthValidation.spec.ts
@@ -1,0 +1,45 @@
+import { MaxLengthValidation } from './MaxLengthValidation';
+import { InvalidFieldError } from '@/validation/errors';
+import faker from 'faker';
+
+const maxLength = faker.datatype.number();
+
+const makeSut = (fieldName: string): MaxLengthValidation =>
+  new MaxLengthValidation(fieldName, maxLength);
+
+describe('MaxLengthValidation', () => {
+  test('Should return error if value is longer than maxLength', () => {
+    const field = faker.database.column();
+    const sut = makeSut(field);
+    const error = sut.validate({
+      [field]: faker.random.alphaNumeric(maxLength + 1),
+    });
+    expect(error).toEqual(new InvalidFieldError());
+  });
+
+  test('Should return falsy if value is equal to maxLength', () => {
+    const field = faker.database.column();
+    const sut = makeSut(field);
+    const error = sut.validate({
+      [field]: faker.random.alphaNumeric(maxLength),
+    });
+    expect(error).toBeFalsy();
+  });
+
+  test('Should return falsy if value is shorter than maxLength', () => {
+    const field = faker.database.column();
+    const sut = makeSut(field);
+    const error = sut.validate({
+      [field]: faker.random.alphaNumeric(maxLength - 1),
+    });
+    expect(error).toBeFalsy();
+  });
+
+  test('Should return falsy if field does not exists in schema', () => {
+    const sut = makeSut(faker.database.column());
+    const error = sut.validate({
+      [faker.database.column()]: faker.random.alphaNumeric(maxLength - 1),
+    });
+    expect(error).toBeFalsy();
+  });
+});

--- a/src/validation/validators/maxLength/MaxLengthValidation.ts
+++ b/src/validation/validators/maxLength/MaxLengthValidation.ts
@@ -1,0 +1,13 @@
+import { InvalidFieldError } from '@/validation/errors';
+import { IFieldValidation } from '@/validation/protocols';
+
+export class MaxLengthValidation implements IFieldValidation {
+  constructor(readonly field: string, private readonly maxLength: number) {}
+
+  validate(input: object): Error {
+    const fieldLength = input[this.field]?.length;
+    return fieldLength && fieldLength > this.maxLength
+      ? new InvalidFieldError()
+      : null;
+  }
+}

--- a/src/validation/validators/minLength/MinLengthValidation.spec.ts
+++ b/src/validation/validators/minLength/MinLengthValidation.spec.ts
@@ -2,27 +2,44 @@ import { MinLengthValidation } from './MinLengthValidation';
 import { InvalidFieldError } from '@/validation/errors';
 import faker from 'faker';
 
+const minLength = faker.datatype.number();
+
 const makeSut = (fieldName: string): MinLengthValidation =>
-  new MinLengthValidation(fieldName, 5);
+  new MinLengthValidation(fieldName, minLength);
 
 describe('MinLengthValidation', () => {
-  test('Should return error if value is invalid', () => {
+  test('Should return error if value is shorter than minLength', () => {
     const field = faker.database.column();
     const sut = makeSut(field);
-    const error = sut.validate({ [field]: faker.random.alphaNumeric(4) });
+    const error = sut.validate({
+      [field]: faker.random.alphaNumeric(minLength - 1),
+    });
     expect(error).toEqual(new InvalidFieldError());
   });
 
-  test('Should return falsy if value is valid', () => {
+  test('Should return falsy if value is equal to minLength', () => {
     const field = faker.database.column();
     const sut = makeSut(field);
-    const error = sut.validate({ [field]: faker.random.alphaNumeric(6) });
+    const error = sut.validate({
+      [field]: faker.random.alphaNumeric(minLength),
+    });
+    expect(error).toBeFalsy();
+  });
+
+  test('Should return falsy if value is longer than minLength', () => {
+    const field = faker.database.column();
+    const sut = makeSut(field);
+    const error = sut.validate({
+      [field]: faker.random.alphaNumeric(minLength + 1),
+    });
     expect(error).toBeFalsy();
   });
 
   test('Should return falsy if field does not exists in schema', () => {
     const sut = makeSut(faker.database.column());
-    const error = sut.validate({ [faker.database.column()]: faker.random.alphaNumeric(6) });
+    const error = sut.validate({
+      [faker.database.column()]: faker.random.alphaNumeric(minLength - 1),
+    });
     expect(error).toBeFalsy();
   });
 });

--- a/src/validation/validators/minLength/MinLengthValidation.ts
+++ b/src/validation/validators/minLength/MinLengthValidation.ts
@@ -5,6 +5,9 @@ export class MinLengthValidation implements IFieldValidation {
   constructor(readonly field: string, private readonly minLength: number) {}
 
   validate(input: object): Error {
-    return input[this.field]?.length <= this.minLength ? new InvalidFieldError() : null;
+    const fieldLength = input[this.field]?.length;
+    return fieldLength && fieldLength < this.minLength
+      ? new InvalidFieldError()
+      : null;
   }
 }


### PR DESCRIPTION
Solves issue #29 

- [x] Added max length validator and tests
- [x] Fixed min length validator so if min length is set to X it wouldn't return an error
- [x] Added tests for field length matching length passed to validators

Reasoning:
most libraries consider both min and max length as valid length values, users would likely expect the same here.